### PR TITLE
handles network ids containing space characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A text-based 802.11 wireless network manager for OpenBSD
 
 ## Archive
-As of OpenBSD 6.4, this application is obsolete. A new feature will allow wireless to join any of multiple wireless networks defined in /etc/hostname.if(5).
+As of OpenBSD 6.4, this application is obsolete. A new feature allows wifi to join any of multiple wireless networks defined in /etc/hostname.if(5).
 
 Thus, I am archiving this project. It will continue to exist in read-only mode for the forseeable time being, just in case.
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ A text-based 802.11 wireless network manager for OpenBSD
 
 ## Walk through
 If you run wiconn without any arguments, it will scan for wireless networks and display them in a list. The network you're connected to will show up with a green background. Open networks are shown with a red background.
-![wiconn.sh network list](http://stuff.h-i-r.net/wiconn/wc1.png)
+
 
 If you have a saved network in ~/.wiconn, you can simply run wiconn.sh with the network name as the first argument.
-![wiconn.sh direct connection](http://stuff.h-i-r.net/wiconn/wc0.png)
+
 
 Wiconn can save a network you've connected to, and can save the BSSID to protect you from most evil twin attacks.
-![wiconn.sh save connection](http://stuff.h-i-r.net/wiconn/wc2.png)
+
 
 The ~/.wiconn file can be used to set the default wireless interface, and also stores wireless network names, WPA keys and (optionally) BSSIDs. It should be readable and writable only by your user (chmod 0600). 
-![~/.wiconn rc file](http://stuff.h-i-r.net/wiconn/wc3.png)
+
 
 ## About
 Written in Bourne shell and relying only on tools available in the OpenBSD

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # wiconn
 A text-based 802.11 wireless network manager for OpenBSD
 
+## Archive
+As of OpenBSD 6.4, this application is obsolete. A new feature will allow wireless to join any of multiple wireless networks defined in /etc/hostname.if(5).
+
+Thus, I am archiving this project. It will continue to exist in read-only mode for the forseeable time being, just in case.
+
 ## Walk through
 If you run wiconn without any arguments, it will scan for wireless networks and display them in a list. The network you're connected to will show up with a green background. Open networks are shown with a red background.
 

--- a/wiconn.sh
+++ b/wiconn.sh
@@ -121,11 +121,12 @@ scan_wifi(){
 }
 
 check_ssids(){
-  if [ $(grep ^${nwid}\| ~/.wiconn) ]
+  res=$(grep -s ^"${nwid}"\| ~/.wiconn)
+  if [ $? = 0 ]
   then
     echo "Found saved wifi"
-    tbssid=$(grep ^${nwid}\| ~/.wiconn | cut -f3 -d\|)
-    wpakey=$(grep ^${nwid}\| ~/.wiconn | cut -f2 -d\|)
+    tbssid=$(echo "${res}" | cut -f3 -d\|)
+    wpakey=$(echo "${res}" | cut -f2 -d\|)
     connect_wifi
   fi
 }
@@ -187,15 +188,16 @@ connect_wifi(){
   then
     echo "Attempting to connect to \033[1m${nwid}\033[0m as an open network..."
     doas /usr/bin/pkill dhclient
-    doas /sbin/ifconfig ${dev} -wpakey nwid ${nwid} ${bssid}
+    doas /sbin/ifconfig ${dev} -wpakey nwid "${nwid}" "${bssid}"
     doas /sbin/dhclient ${dev}
   else
     echo "Attempting to connect to \033[1m${nwid}\033[0m with WPA key..."
     doas /usr/bin/pkill dhclient
-    doas /sbin/ifconfig ${dev} nwid ${nwid} wpakey ${wpakey} ${bssid}
+    doas /sbin/ifconfig ${dev} nwid "${nwid}" wpakey "${wpakey}" "${bssid}"
     doas /sbin/dhclient ${dev} 
   fi 
-  if [ $(grep ^${nwid}\| ~/.wiconn) ]
+  grep -s ^"${nwid}"\| ~/.wiconn  > /dev/null
+  if [ $? = 0 ]
   then
     exit 0
   else
@@ -244,11 +246,12 @@ then
   setup_wifi
 fi
 
-if [ `grep ^${nwid}\| ~/.wiconn` ]
+res=$(grep ^"${nwid}"\| ~/.wiconn)
+if [ $? = 0 ]
 then
   echo "Found saved access point"
-  tbssid=`grep ^${nwid}\| ~/.wiconn | cut -f3 -d\|`
-  wpakey=`grep ^${nwid}\| ~/.wiconn | cut -f2 -d\|`
+  tbssid=$(echo "$res" | cut -f3 -d\|)
+  wpakey=$(echo "$res" | cut -f2 -d\|)
   connect_wifi
 fi
 


### PR DESCRIPTION
I really like using this project. This makes it work with space characters in network ids.

Some commands were split into two lines because of quoting needs.
